### PR TITLE
Add basic camera loop

### DIFF
--- a/camera_loop.py
+++ b/camera_loop.py
@@ -1,0 +1,34 @@
+import cv2
+import numpy as np
+
+# start video
+cap = cv2.VideoCapture(0)
+
+while cap.isOpened():
+    ret, frame = cap.read()
+    if ret is None:
+        continue
+
+    # convert frame to RGB for detection model
+    frame = cv2.cvtColor(cv2.flip(frame, 1), cv2.COLOR_BGR2RGB)
+
+
+    # TODO:
+    # insert detection model here
+
+
+    # convert frame back to BGR to displaying
+    frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+
+    # display window
+    window = 'Distraction Detection'
+    cv2.namedWindow(window)
+    cv2.moveWindow(window, 100, 50)
+    cv2.imshow(window, frame)
+
+    # check for escape key
+    if cv2.waitKey(1) == 27:
+        break
+
+cap.release()
+cv2.destroyAllWindows()


### PR DESCRIPTION
Adds simple loop for capturing video stream using OpenCV. Video frames can be sent to a computer vision model for distraction detection.

The camera loop displays the user's camera to them in a pop-up window. This is so we can visually see when the app is detecting the user is distracted and also get feedback on how fast the CV model runs. This will also be good when demo-ing the functionality.