### PR TITLE
Add detection threshold to camera loop

### DIFF
--- a/camera_loop.py
+++ b/camera_loop.py
@@ -1,8 +1,22 @@
 import cv2
 import numpy as np
 
+IS_RECORDING = False
+
 # start video
 cap = cv2.VideoCapture(0)
+fps = cap.get(cv2.CAP_PROP_FPS) or 30
+
+# create buffer for how long a user should stay distracted for
+buffer_idx = 0
+buffer_size = int(4 * fps)
+distracted_buffer = np.zeros(buffer_size, dtype=np.int8)
+
+# placeholder function for distraction detection
+def is_distracted():
+    """Test distraction by pressing space bar"""
+    return int(cv2.waitKey(1) == ord(' '))
+
 
 while cap.isOpened():
     ret, frame = cap.read()
@@ -12,10 +26,21 @@ while cap.isOpened():
     # convert frame to RGB for detection model
     frame = cv2.cvtColor(cv2.flip(frame, 1), cv2.COLOR_BGR2RGB)
 
+    # TODO: replace with call to detection models
+    distracted = is_distracted()
 
-    # TODO:
-    # insert detection model here
+    distracted_buffer[buffer_idx] = distracted
+    distraction_avg = np.average(distracted_buffer)
+    buffer_idx = (buffer_idx + 1) % buffer_size
 
+    # Check when to start/stop recording
+    if distraction_avg >= 0.8 and not IS_RECORDING:
+        IS_RECORDING = True
+        print('START RECORDING')
+
+    if distraction_avg <= 0.1 and IS_RECORDING:
+        IS_RECORDING = False
+        print('STOP RECORDING')
 
     # convert frame back to BGR to displaying
     frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)


### PR DESCRIPTION
Implements a circular buffer to find distraction rate over the last few seconds. If the distraction rate is above a specific threshold, we can start recording.

This is needed to make the application more robust to outliers from the model predictions. It is also useful for preventing very momentary distractions from triggering a summary pop-up.