### PR TITLE
Replace opencv waitkey with keyboard

### DIFF
--- a/detection_model.py
+++ b/detection_model.py
@@ -1,16 +1,16 @@
 import cv2
+import keyboard
 import numpy as np
 from utils.onnx_utils import create_ort_session
 
 MP_landmark = create_ort_session("models/mediapipe_face-facelandmarkdetector-w8a8.onnx")
 
+
 def is_distracted(frame):
-    # dummy return for now. Can trigger by pressing spacebar
-    return int(cv2.waitKey(1) == ord(' '))
-
-    # TODO: use model output to calculate if "distracted"
-    output = get_model_ouptut(frame)
-
+    # Actual key check
+    space_pressed = int(keyboard.is_pressed('space'))
+    #print(space_pressed) # uncomment to test keyboard input detection
+    return space_pressed
 
 def get_model_ouptut(image):
     # resize image to model input shape

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 coloredlogs==15.0.1
 flatbuffers==25.2.10
 humanfriendly==10.0
+keyboard==0.13.5
 mpmath==1.3.0
 netron==8.4.4
 numpy==2.2.6


### PR DESCRIPTION
opencv waitkey is inconsistent in picking up keyboard input. Switching to 'keyboard' instead.