### PR TITLE
Add basic distraction metric using face detection model

### DIFF
--- a/detection_model.py
+++ b/detection_model.py
@@ -5,11 +5,10 @@ from utils.onnx_utils import create_ort_session
 MP_landmark = create_ort_session("models/mediapipe_face-facelandmarkdetector-w8a8.onnx")
 
 def is_distracted(frame):
-    # dummy return for now. Can trigger by pressing spacebar
-    return int(cv2.waitKey(1) == ord(' '))
-
-    # TODO: use model output to calculate if "distracted"
-    output = get_model_ouptut(frame)
+    score, landmarks = get_model_ouptut(frame)
+    # TODO: implement more complicated distraction detection based on face landmarks
+    # print(score)
+    return int(score > 0.8)
 
 
 def get_model_ouptut(image):


### PR DESCRIPTION
MediaPipe Face Landmark produces a prediction score on if a face is detected. We will use this score to determine if a user is distracted or not before using more compilated scoring metrics.