### PR TITLE
Fix frame rendering for camera loop

### DIFF
--- a/camera_loop.py
+++ b/camera_loop.py
@@ -70,6 +70,9 @@ while cap.isOpened():
     if keyboard.is_pressed('esc'):
         break
 
+    # require waitKey to update frames
+    cv2.waitKey(1)
+
 # kill chatbot
 kill_chatbot(chatbot)
 


### PR DESCRIPTION
cv2.waitKey() needs to be called every so often for cv2.imshow() to render and update frames. Add empty call at the end of the loop.