### PR TITLE
Remove context_enable option from create_ort_session

### DIFF
--- a/utils/onnx_utils.py
+++ b/utils/onnx_utils.py
@@ -4,7 +4,6 @@ import onnxruntime as ort
 def create_ort_session(model_path: str):
     # cache our model to reduce load times
     options = ort.SessionOptions()
-    options.add_session_config_entry("ep.context_enable", 1)
 
     session = ort.InferenceSession(
         model_path,


### PR DESCRIPTION
This was creating runtime errors. Removing this option for now.